### PR TITLE
fix example

### DIFF
--- a/MapView/viewController.m
+++ b/MapView/viewController.m
@@ -204,7 +204,7 @@ CustomMKCircleOverlay *circleView;
     
     if(circle != nil)
         [self.mapView removeOverlay:circle];
-    circle = [MKCircle circleWithCenterCoordinate:droppedAt radius:circleRadius];
+    circle = [MKCircle circleWithCenterCoordinate:droppedAt radius:2000.0]; //Set the radius to the maximum circle size or larger
     
     [self.mapView addOverlay: circle];
 


### PR DESCRIPTION
Fix for IOS 10 example.  

It is important to set the MKCircle radius to the maximum circle radius.  
